### PR TITLE
Implementation Guide (IG) Links

### DIFF
--- a/modules/fhir-community.qmd
+++ b/modules/fhir-community.qmd
@@ -29,7 +29,7 @@ The [HL7](https://hl7.org) FHIR community consists of developers, maintainers, a
 -   Health-focused companies and non-profits
 -   Local, state, and federal health agencies
 
-Because [FHIR](https://hl7.org/fhir/) is an open-source specification, most of HL7's FHIR work is done publicly, and anyone may [participate](https://confluence.hl7.org/display/HL7/Participating+in+HL7). The FHIR community also develops many [FHIR Implementation Guides (IGs)](http://fhir.org/guides/registry/) with the same public approach.
+Because [FHIR](https://hl7.org/fhir/) is an open-source specification, most of HL7's FHIR work is done publicly, and anyone may [participate](https://confluence.hl7.org/display/HL7/Participating+in+HL7). The FHIR community also develops many [Implementation Guides (IGs)](data-modeling-reading-igs.qmd) that may be found at the [FHIR Implementation Guide Registry](http://fhir.org/guides/registry/) with the same public approach.
 
 This openness makes members of the community accessible to implementers and developers who want to:
 

--- a/modules/fhir-from-1000-ft.qmd
+++ b/modules/fhir-from-1000-ft.qmd
@@ -28,7 +28,7 @@ This module looks at how FHIR works from a technical standpoint, and is targeted
 
 The FHIR specification groups data elements into "[resources](https://www.hl7.org/fhir/resource.html)," like [Patient](https://www.hl7.org/fhir/patient.html) for representing demographics and administrative information about an individual, and [Observation](https://www.hl7.org/fhir/observation.html) for representing measurements and assertions about a patient or other subject.
 
-FHIR implementers can constrain what information gets included in a FHIR resource or use FHIR extensions to add information to a resource. They can also specify which FHIR resources should be used together for their use case. They share these constraints, extensions, and combinations with others through an Implementation Guide.
+FHIR implementers can constrain what information gets included in a FHIR resource or use FHIR extensions to add information to a resource. They can also specify which FHIR resources should be used together for their use case. They share these constraints, extensions, and combinations with others through an [Implementation Guide (IG)](data-modeling-reading-igs.qmd).
 
 Below is a screenshot of the [Patient resource](https://www.hl7.org/fhir/R4B/patient.html) from the FHIR specification (`R4B` version):
 
@@ -100,7 +100,7 @@ The FHIR specification follows [the 80/20 rule](http://www.healthintersections.c
 
 To maximize usability, data elements contained in FHIR resources have minimal constraints. **Constraints** restrict how a data element can be populated. For example, a constraint on Patient resource might require that `Patient.birthDate` be populated. However, some systems record a patient's age in years rather than date of birth for privacy reasons. If the constraint on `Patient.birthDate` existed, those system would not be able to use the Patient resource.
 
-However, some use cases may require `Patient.birthDate` be populated. To achieve this, implementers can define use case-specific constraints on top of the base FHIR specification through **profiling**. The output of profiling is an **Implementation Guide (IG)**, which is a collection of **profiles** that build on top of the FHIR specification (or other IGs).
+However, some use cases may require `Patient.birthDate` be populated. To achieve this, implementers can define use case-specific constraints on top of the base FHIR specification through **profiling**. The output of profiling is an [Implementation Guide (IG)](data-modeling-reading-igs.qmd), which is a collection of **profiles** that build on top of the FHIR specification (or other IGs).
 
 ### Example: customizing Patient in US Core
 
@@ -160,8 +160,8 @@ Note that extensions can make interoperability more difficult compared to using 
 
 There are two research considerations for customizing FHIR:
 
-1.  **Are there existing FHIR IGs that are relevant?** For example, oncology clinical trials might be able to take advantage of the [mCODE IG](https://hl7.org/fhir/us/mcode/). Find other potentially relevant IGs [here](data-modeling-real-world-igs.qmd).
-2.  **Would creating a FHIR IG provide value?** For research that uses FHIR-formatted data, creating a study-specific IG provides a way to easily define element definitions and required data elements. More information [on writing IGs is here](data-modeling-writing-igs.qmd).
+1.  **Are there existing FHIR Implementation Guides that are relevant?** For example, oncology clinical trials might be able to take advantage of the [mCODE IG](https://hl7.org/fhir/us/mcode/). Find other potentially relevant IGs [here](data-modeling-real-world-igs.qmd).
+2.  **Would creating a FHIR Implementation Guide provide value?** For research that uses FHIR-formatted data, creating a study-specific IG provides a way to easily define element definitions and required data elements. More information [on writing IGs is here](data-modeling-writing-igs.qmd).
 
 ## Connecting systems together: the FHIR API
 
@@ -175,7 +175,7 @@ The diagram below shows how FHIR's API connects systems to each other:
 
 For example, a FHIR Client (like the Apple Health app on an iPhone) can request data from a FHIR server using the "RESTful API over HTTP." FHIR standardizes the request so the Apple Health app can use the same request regardless of which FHIR server they contact.
 
-Like with FHIR resources, the standard FHIR API doesn't define all necessary operations for every use case. FHIR Implementation Guides (IGs) can also define additional API capabilities for a specific use case.
+Like with FHIR resources, the standard FHIR API doesn't define all necessary operations for every use case. FHIR [Implementation Guides (IGs)](data-modeling-reading-igs.qmd) can also define additional API capabilities for a specific use case.
 
 ## Research implications
 

--- a/modules/genomics.qmd
+++ b/modules/genomics.qmd
@@ -63,7 +63,7 @@ The mCODE standards specifications team works closely with the HL7 CGWG to ensur
 
 ### Phenopackets
 
-The [Global Alliance for Genomics and Health](https://www.ga4gh.org/) (GA4GH) [Phenopacket standard](https://www.ga4gh.org/news_item/phenopackets-standardizing-and-exchanging-patient-phenotypic-data/) is not native FHIR-based standard. Rather it is a lightweight specification intends to support global exchange of computable case-level phenotypic information for all types of disease diagnosis and research. However, the specification was ported to a [FHIR implementation guide](http://phenopackets.org/core-ig/ig/branch/master/index.html) and currently under development. The Phenopackets designers are working closely with the CCWG to align both standards.
+The [Global Alliance for Genomics and Health](https://www.ga4gh.org/) (GA4GH) [Phenopacket standard](https://www.ga4gh.org/news_item/phenopackets-standardizing-and-exchanging-patient-phenotypic-data/) is not a native FHIR-based standard. Rather it is a lightweight specification that intends to support global exchange of computable case-level phenotypic information for all types of disease diagnosis and research. However, the specification was ported to a [GA4GH Phenopacket FHIR Implementation Guide](http://phenopackets.org/core-ig/ig/branch/master/index.html) and is currently under development. The Phenopackets designers are working closely with the CCWG to align both standards.
 
 ### Other genomics-related HL7 specifications
 

--- a/modules/key-fhir-resources.qmd
+++ b/modules/key-fhir-resources.qmd
@@ -509,7 +509,7 @@ Properly implemented FHIR servers must provide an instance of CapabilityStatemen
 
 [Condition](https://hl7.org/fhir/condition.html)
 
-:   A problem, diagnosis, or clinical event. It should be the reason for a medical intervention and tie into a larger [clinical workflow](http://hl7.org/fhir/workflow.html). There is some use-case overlap with `Observation`; an [IG](data-modeling-real-world-igs.qmd) will provide better guidance.
+:   A problem, diagnosis, or clinical event. It should be the reason for a medical intervention and tie into a larger [clinical workflow](http://hl7.org/fhir/workflow.html). There is some use-case overlap with `Observation`; an IG will provide better guidance.
 
 [Procedure](https://hl7.org/fhir/procedure.html)
 


### PR DESCRIPTION
This PR represents a pass across the site focusing on linking IG references to the "Reading IGs" section.  It has a conservative focus on the first mention of IG on a page, expanding the acronym in early learning material, and consistency across the site.

Changes
- Changed wording in `fhir-community.qmd` to be more explicit that a link is to the FHIR IG registry
- Added links and a couple word changes in `fhir-from-1000-ft.qmd`
- Link and a couple grammar updates in `genomics.qmd`
- Removed link in list in `key-fhir-resources.qmd` to be consistent with other IG mentions in list