### PR TITLE
Advanced Topics Sections

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -122,7 +122,6 @@ website:
             - file: modules/synthea-test-server.qmd
               text: FHIR Test Server
         - fhir-versions.qmd
-        - contribute.qmd
         - style-guide.qmd
 
 

--- a/contribute.qmd
+++ b/contribute.qmd
@@ -1,5 +1,5 @@
 ---
-title: Questions & Corrections
+title: Questions & Contributions
 toc: false
 sidebar: false
 ---

--- a/contribute.qmd
+++ b/contribute.qmd
@@ -1,5 +1,5 @@
 ---
-title: Contributions & Corrections
+title: Questions & Corrections
 toc: false
 sidebar: false
 ---

--- a/fhir-versions.qmd
+++ b/fhir-versions.qmd
@@ -1,7 +1,5 @@
 ---
 title: "FHIR Versions"
-
-toc: false
 number-sections: false
 ---
 

--- a/sections/advanced-topics.qmd
+++ b/sections/advanced-topics.qmd
@@ -15,5 +15,4 @@ sidebar: false
 ## Other Topics
 
 -   [FHIR Versions](/fhir-versions.qmd)
--   [Making Contributions to This Website](/contribute.qmd)
 -   [Style Guide](/style-guide.qmd)

--- a/style-guide.qmd
+++ b/style-guide.qmd
@@ -1,6 +1,5 @@
 ---
 title: Style Guide
-sidebar: false
 ---
 
 We use the [RStudio Visual R Markdown](https://rstudio.github.io/visual-markdown-editing/) interchangeably with writing raw Markdown in another editor like VSCode. Visual R Markdown will automatically reformat `.md` or `.qmd` files when opening them, so we do not get hung up on specific Markdown styling as we accept the default output of Visual R Markdown.


### PR DESCRIPTION
Previously, when in the Advanced Topics section and clicking on Contributions, Versions, or the Style Guide, the navigation would be lost on the left.  This wasn't consistent with the other navigation in the site.  Behavior updated.

Changes
- `Questions and Contributions` removed from Advanced Topics.  Q&C is prominently available from the main navigation bar, which made it unique by being a subsection to another main navigation item.  Now presented as it's own section (not a subsection to another)
- Title of `contribute.qmd` updated to `Questions and Contributions`
- Navigation menu behavior for Versions and Style Guide updated for consistency with the other Advanced Topics pages