### PR TITLE
Add balloting implications for researchers

### DIFF
--- a/modules/fhir-community.qmd
+++ b/modules/fhir-community.qmd
@@ -171,7 +171,7 @@ community will move on before the specification is declared “fit for use”.
 
 > ...the formal process that HL7 uses to get feedback and comments on specifications prior to publication. Rules governing balloting are defined in both [HL7's Governance and Operations Manual](http://www.hl7.org/documentcenter/public./membership/HL7_Governance_and_Operations_Manual.pdf) and in the [HL7 Essential Requirements](http://www.hl7.org/documentcenter/public/procedures/HL7_Essential_Requirements.pdf). These, in turn, are governed by the expectations of the American National Standards Institute (ANSI) which accredits HL7 as a standards development organization and enforces rules around the openness and fairness of approval processes. The objective of balloting is to actively seek feedback on a proposed standard and to ensure that the community that will be governed by that standard is in agreement with the expectations set by the standard. 
 
-### HL7 ballot process and levels
+### HL7 ballot process and levels {#ballot-levels}
 
 For a project that wants to pursue the HL7 balloting process, the first step is to [create an HL7 Project Proposal](https://confluence.hl7.org/display/HL7/How+to+Create+and+Review+a+Project+Proposal). Project Proposals are reviewed by HL7 co-chairs and approved by a sponsoring Work Group that fits with the content or subject matter for the proposal. After the Project Proposal is approved by the sponsoring Work Group, a [Project Scope Statement](https://confluence.hl7.org/display/HL7/How+to+Create+a+Project+Scope+Statement+in+JIRA), which includes more detailed information about the proposed project, must be submitted and reviewed.
 
@@ -182,7 +182,9 @@ The next step in the [balloting process](https://confluence.hl7.org/display/HL7/
 3. **Standard for Trial Use (STU)**: for vetting content that will be binding on implementers. IGs in this ballot period are ready to be used but have not been widely implemented.
 4. **Normative**: this stage is the final ballot level and once the requirements are meant, IGs at this level are authoritative. A high level of consensus is required to meet the normative status since any changes are binding.
 
-During a ballot, a specification is "frozen" for a specified period of time to give balloters time to submit comments to raise issues or propose changes. Balloters may cast votes to publish the specification. The sponsoring Work Group will review the comments to resolve issues raised during a ballot. 
+During a ballot, a specification is "frozen" for a specified period of time to give balloters time to submit comments to raise issues or propose changes. Balloters may cast votes to publish the specification. The sponsoring Work Group will review the comments to resolve issues raised during a ballot.
+
+The significance of the balloting process and ballot levels for researchers is discussed more in [Balloting implications for researchers](#balloting-and-research).
 
 ### HL7 ballot examples
 
@@ -197,7 +199,6 @@ Two research related IGs undergoing the HL7 balloting process are the following:
 
 2. The [Single Institutional Review Board (sIRB)](http://hl7.org/fhir/us/sirb/) IG aims to facilitate multi-site research by combining individual IRB requirements into a single application process, lowering administrative burdens and expediting the research process.
 
-
 ### Pros of balloting through HL7
 
 There are several benefits of balloting an IG through HL7, including **visibility, implementation, and reusability**:
@@ -205,7 +206,6 @@ There are several benefits of balloting an IG through HL7, including **visibilit
 - **Visibility**: developing projects are socialized early and often throughout the balloting process, so many stakeholders within the HL7 community are aware of them
 - **Implementation**: greater visibility prevents standards from being developed in isolation. Successful implementation is more likely since there are many opportunities for the potential future implementors to offer input throughout the balloting process
 - **Reusability**: the combination of visibility and successful implementation supports reusability of the profiles within an IG, which is beneficial for the standards development process. Reusing existing IG content is conducive to interoperability.
-
 
 ### Cons of balloting through HL7
 
@@ -216,6 +216,13 @@ Two IGs that were not balloted through HL7:
 1. The [NIH Cloud Platform Interoperability Effort (NCPI) FHIR Implementation Guide](https://nih-ncpi.github.io/ncpi-fhir-ig/index.html) (NCPI FHIR IG) is a relatively newer IG that is still under development. The IG aims to support data and knowledge-sharing among researchers by using FHIR as a standard, common model for representing data.
 
 2. The [OHSU Hypertension Implementation Guide](https://build.fhir.org/ig/OHSUCMP/htnu18ig/index.html) is a patient-facing support tool for hypertension management. Funded by AHRQ, the IG uses [CDS Hooks](smart-on-fhir-intro/#cds-hooks)to support the clinical decision support logic.
+
+### Balloting implications for researchers {#balloting-and-research}
+
+There are implications and considerations for researchers that may want to use an existing specification that is moving through the balloting process or ballot their own specification.
+
+- **Consider the ballot level.** Specifications that are earlier in the [balloting stages](#ballot-levels) are more likely to change as they mature. It would be riskier to base a research project on the assumption that the IG will remain as it's written.  
+- **Is community consensus important?** If garnering a strong community and consensus among the group is important to the success of a research effort, then balloting would likely help. Generally, adoption and implementation are more likely for IG's that go through the balloting process. Particularly if industry support is desired, balloting is a great way to socialize an idea and unite interested stakeholders. 
 
 ### More information on balloting
 The balloting process can be daunting and confusing after the first introduction. The following steps may help to clarify the process:


### PR DESCRIPTION
Add two considerations for researchers on the balloting process and how it relates to research:
- Specs in earlier ballot stages are more likely to change
- Balloting can help build community support and consensus if that is important