### PR TITLE
Update R package versions and gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ bibliography.bib.*
 # Ignore Jupyter Checkpoints
 .ipynb_checkpoints
 .jupyter-cache
+
+# Exclude cache files for Jupyter and tabular-r
+modules/.jupyter_cache/
+modules/tabular-r_cache/

--- a/renv.lock
+++ b/renv.lock
@@ -1,4 +1,4 @@
-{
+ {
   "R": {
     "Version": "4.2.0",
     "Repositories": [
@@ -37,7 +37,7 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.4-1",
+      "Version": "1.7-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -467,7 +467,7 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.5.2",
+      "Version": "1.6.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -511,7 +511,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.2",
+      "Version": "3.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -615,7 +615,7 @@
     },
     "haven": {
       "Package": "haven",
-      "Version": "2.5.2",
+      "Version": "2.5.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -725,7 +725,7 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.4",
+      "Version": "1.8.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -825,7 +825,7 @@
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.8-40",
+      "Version": "1.9-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -881,7 +881,7 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-157",
+      "Version": "3.1-165",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1174,7 +1174,7 @@
     },
     "scales": {
       "Package": "scales",
-      "Version": "1.2.1",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1489,7 +1489,7 @@
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.3",
+      "Version": "1.3.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [


### PR DESCRIPTION
This PR updates several R package versions in the renv.lock file and adds some rules to .gitignore.

Changes:
- Updated versions for Matrix, fs, ggplot2, haven, jsonlite, mgcv, nlme, scales, and xml2 packages
- Added .jupyter_cache and tabular-r_cache to .gitignore

Please review these changes and let me know if any adjustments are needed.